### PR TITLE
maven-surefire-plugin should use property defined by jacoco-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <argLine>--enable-preview</argLine>
     </properties>
 
     <build>
@@ -36,9 +37,6 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
-                <configuration>
-                    <argLine>--enable-preview</argLine>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
Before this change [log in TravisCI shows](https://travis-ci.com/Teemitze/TelegramBot/builds/151255693#L4545-L4546)

```
[INFO] --- jacoco-maven-plugin:0.8.5:report (report) @ TelegramBot ---
[INFO] Skipping JaCoCo execution due to missing execution data file.
```

After this change [log in TravisCI shows](https://travis-ci.com/Teemitze/TelegramBot/builds/151331415#L4554-L4556)

```
[INFO] --- jacoco-maven-plugin:0.8.5:report (report) @ TelegramBot ---
[INFO] Loading execution data file /home/travis/build/Teemitze/TelegramBot/target/jacoco.exec
[INFO] Analyzed bundle 'TelegramBot' with 18 classes
```